### PR TITLE
Fix price parsing for no-space '억' formats

### DIFF
--- a/scraper_trade_rs_stream.py
+++ b/scraper_trade_rs_stream.py
@@ -127,8 +127,9 @@ def clean_price(price_str):
     if not price_str:
         return ""
     
-    # Replace Korean currency symbols/words and standardize
-    price_str = price_str.replace("억", "").strip()
+    # Replace the Korean "억" unit with a space so both "5억 2,000" and
+    # "5억2,000" formats are handled consistently
+    price_str = price_str.replace("억", " ").strip()
     
     # Handle price formats like "5억 2,000"
     parts = price_str.split()


### PR DESCRIPTION
## Summary
- handle price strings that omit spaces after the '억' unit

## Testing
- `python -m py_compile scraper_trade_rs_stream.py`
- `python - <<'PY'
from scraper_trade_rs_stream import clean_price
print(clean_price('5억 2,000'))
print(clean_price('5억2,000'))
print(clean_price('3억'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892fb15283c8329896352c723f124c4